### PR TITLE
Sped up average RGB value calculation by an order of magnitude

### DIFF
--- a/lights.py
+++ b/lights.py
@@ -4,7 +4,7 @@ from appJar import gui
 import os
 import time
 import binascii
-import lifxlan 
+import lifxlan
 import colorsys
 from colour import Color
 import math
@@ -28,7 +28,7 @@ elif (myos == 'Linux'):
     import pyscreenshot as ImageGrab
 
 
- 
+
 
 DECIMATE  = 1   # skip every DECIMATE number of pixels to speed up calculation
 TRANSIENT_TIP = "If selected, return to the original color after the specified number of cycles. If not selected, set light to specified color"
@@ -92,8 +92,8 @@ def SceneNameChanged(name):
     print(name, "Entry changed")
     config[name] = app.getEntry(name)
     config.write()
-    
-    
+
+
 
 def Scene(name):
     global original_colors1
@@ -104,33 +104,33 @@ def Scene(name):
     global original_powers3
     global lan
     global config
-    
+
     print(name, "button pressed")
     if len(bulbs) < 1:
         app.errorBox("Error", "Error. No bulbs were found yet. Please click the 'Find Bulbs' button and try again.")
         return
     try:
-            
+
         if name == 'Save Scene 1':
             print("Saving Scene 1")
             original_colors1 = lan.get_color_all_lights()
             original_powers1 = lan.get_power_all_lights()
             #print("colors:",original_colors)
             #print(type(original_colors1))
-            pkl.dump(original_colors1, open(SCENE1_C, "wb" ))   
-            pkl.dump(original_powers1, open(SCENE1_P, "wb" ))   
-        
-        
+            pkl.dump(original_colors1, open(SCENE1_C, "wb" ))
+            pkl.dump(original_powers1, open(SCENE1_P, "wb" ))
+
+
         elif name == 'Restore Scene 1':
             print("Restoring Scene 1")
             if (os.path.exists(SCENE1_C) and os.path.exists(SCENE1_P) ):
-                original_colors1 = pkl.load(open(SCENE1_C , "rb"))   
-                original_powers1 = pkl.load(open(SCENE1_P , "rb"))   
-        
+                original_colors1 = pkl.load(open(SCENE1_C , "rb"))
+                original_powers1 = pkl.load(open(SCENE1_P , "rb"))
+
             if ( (len(original_colors1) == 0) or (len(original_powers1) == 0) ):
                 print("Nothing saved yet.")
                 return
-            
+
             print("Restoring original color to all lights...")
             #print("colors:",original_colors)
             for light in original_colors1:
@@ -146,20 +146,20 @@ def Scene(name):
             original_colors2 = lan.get_color_all_lights()
             original_powers2 = lan.get_power_all_lights()
             #print("colors:",original_colors)
-            pkl.dump(original_colors2, open(SCENE2_C, "wb" ))   
-            pkl.dump(original_powers2, open(SCENE2_P, "wb" ))   
-        
-        
+            pkl.dump(original_colors2, open(SCENE2_C, "wb" ))
+            pkl.dump(original_powers2, open(SCENE2_P, "wb" ))
+
+
         elif name == 'Restore Scene 2':
             print("Restoring Scene 2")
             if (os.path.exists(SCENE2_C) and os.path.exists(SCENE2_P) ):
-                original_colors2 = pkl.load(open(SCENE2_C , "rb"))   
-                original_powers2 = pkl.load(open(SCENE2_P , "rb"))   
-        
+                original_colors2 = pkl.load(open(SCENE2_C , "rb"))
+                original_powers2 = pkl.load(open(SCENE2_P , "rb"))
+
             if ( (len(original_colors2) == 0) or (len(original_powers2) == 0) ):
                 print("Nothing saved yet.")
                 return
-            
+
             print("Restoring original color to all lights...")
             #print("colors:",original_colors)
             for light in original_colors2:
@@ -175,19 +175,19 @@ def Scene(name):
             original_colors3 = lan.get_color_all_lights()
             original_powers3 = lan.get_power_all_lights()
             #print("colors:",original_colors)
-            pkl.dump(original_colors3, open(SCENE3_C, "wb" ))   
-            pkl.dump(original_powers3, open(SCENE3_P, "wb" ))   
-        
+            pkl.dump(original_colors3, open(SCENE3_C, "wb" ))
+            pkl.dump(original_powers3, open(SCENE3_P, "wb" ))
+
         elif name == 'Restore Scene 3':
             print("Restoring Scene 3")
             if (os.path.exists(SCENE3_C) and os.path.exists(SCENE3_P) ):
-                original_colors3 = pkl.load(open(SCENE3_C , "rb"))   
-                original_powers3 = pkl.load(open(SCENE3_P , "rb"))   
-        
+                original_colors3 = pkl.load(open(SCENE3_C , "rb"))
+                original_powers3 = pkl.load(open(SCENE3_P , "rb"))
+
             if ( (len(original_colors3) == 0) or (len(original_powers3) == 0) ):
                 print("Nothing saved yet.")
                 return
-            
+
             print("Restoring original color to all lights...")
             #print("colors:",original_colors)
             for light in original_colors3:
@@ -201,25 +201,25 @@ def Scene(name):
     except Exception as e:
         print ("Ignoring error: ", str(e))
         app.errorBox("Error", str(e)+"\n\n Scene Operation failed. This feature is buggy and only works about 50% of the time. Sometimes, you can still save and restore a scene despite this error. If you keep getting this error and can not perform a 'Restore', try restarting the app then try again.")
-        return        
-    
-    
+        return
+
+
 
 def updateSliders(hsbk):
     #print("h:",hsbk[0])
     #print("s:",hsbk[1])
     #print("b:",hsbk[2])
     #print("k:",hsbk[3])
-    
+
     app.setSpinBox("hueSpin", int(hsbk[0]),callFunction=False)
     app.setSpinBox("satSpin", int(hsbk[1]),callFunction=False)
     app.setSpinBox("briSpin", int(hsbk[2]),callFunction=False)
     app.setSpinBox("kelSpin", int(hsbk[3]),callFunction=False)
-    app.setScale("hueScale", int(hsbk[0]),callFunction=False)    
-    app.setScale("satScale", int(hsbk[1]),callFunction=False)    
-    app.setScale("briScale", int(hsbk[2]),callFunction=False)    
-    app.setScale("kelScale", int(hsbk[3]),callFunction=False)    
-    
+    app.setScale("hueScale", int(hsbk[0]),callFunction=False)
+    app.setScale("satScale", int(hsbk[1]),callFunction=False)
+    app.setScale("briScale", int(hsbk[2]),callFunction=False)
+    app.setScale("kelScale", int(hsbk[3]),callFunction=False)
+
 
 # function to convert the scale values to an RGB hex code
 def getHSB():
@@ -247,7 +247,7 @@ def updateHSB(name):
     # split the widget's name into the type & colour
     colour = name[0:3]
     widg = name[3:]
-    
+
     # get the current RGB value
     HSB = getHSB()
     #print("HSB:",HSB,"type(HSB)",type(HSB))
@@ -270,21 +270,21 @@ def updateHSB(name):
     k = HSB["K"];#print("v:",v)
 
     rgb1= hsv_to_rgb(h,s,v);#print("rgb1:",rgb1)
-    c = Color(rgb=(rgb1[0], rgb1[1], rgb1[2])) 
+    c = Color(rgb=(rgb1[0], rgb1[1], rgb1[2]))
     #print("c:",c)
     app.setLabelBg("bulbcolor", c.hex_l)
-    
+
     global selected_bulb
     bulbHSBK = [HSB["H"],HSB["S"],HSB["B"],k]
     #print ("bulbHSBK:",bulbHSBK)
-    
+
     if gSelectAll:
         lan.set_color_all_lights(bulbHSBK, duration=0, rapid=False)
-        
+
     elif selected_bulb:
         #print("sending color",hsv)
         selected_bulb.set_color(bulbHSBK, duration=0, rapid=False)
-    
+
     #app.setEntry("colCode", RGB)
 
 
@@ -294,7 +294,7 @@ def selectAllPressed (name):
         app.errorBox("Error", "Error. No bulbs were found yet. Please click the 'Find Bulbs' button and try again.")
         app.setCheckBox("Select All", ticked=False, callFunction=False)
         return
-        
+
     global gSelectAll
     gSelectAll = app.getCheckBox("Select All")
     #print("gSelectAll:",gSelectAll)
@@ -307,7 +307,7 @@ def expectedPressed (name):
     config.write()
     #print("gExpectedBulbs:",gExpectedBulbs)
 
-    
+
 def rgb_to_hsv(r, g, b):
     r = float(r)
     g = float(g)
@@ -330,8 +330,8 @@ def rgb_to_hsv(r, g, b):
         h /= 6
 
     return h, s, v
-    
-    
+
+
 def hsv_to_rgb(h, s, v):
     i = math.floor(h*6)
     f = h*6 - i
@@ -364,7 +364,7 @@ def listChanged():
                 #print("Found selected bulb")
                 selected_bulb = bulb
                 details =str(selected_bulb)
-                #print("type(bulb)",type(bulb))                
+                #print("type(bulb)",type(bulb))
                 #print(bulb)
                 #print("breaking")
                 break
@@ -373,13 +373,13 @@ def listChanged():
         app.errorBox("Error", str(e))
         app.clearTextArea("Result");
         app.setTextArea("Result", str(e))
-        
+
         return
-                
-    
+
+
     app.clearTextArea("Result")
     app.setTextArea("Result", details)
-    
+
     try:
         if "Power: On" in details:
             #print ("BULB is ON")
@@ -389,27 +389,27 @@ def listChanged():
             app.setButtonImage("Light","bulb_off.gif")
     except Exception as e:
         print ("Ignoring error:", str(e))
-    
-    app.setButton ( "Light", "Toggle "+selected )    
+
+    app.setButton ( "Light", "Toggle "+selected )
     app.showButton("Light")
-    color = bulb.get_color();#print(color[0],color[1],color[2]); 
+    color = bulb.get_color();#print(color[0],color[1],color[2]);
     h = color[0]/65535.0;#print("h:",h)
     s = color[1]/65535.0;#print("s:",s)
     v = color[2]/65535.0;#print("v:",v)
 
     rgb1= hsv_to_rgb(h,s,v);#print("rgb1:",rgb1)
-    c = Color(rgb=(rgb1[0], rgb1[1], rgb1[2])) 
+    c = Color(rgb=(rgb1[0], rgb1[1], rgb1[2]))
     #print("c:",c)
     app.setLabelBg("bulbcolor", c.hex_l)
     updateSliders(color)
-    
+
 
 def finder():
     global bulbList
     global lan
     global gExpectedBulbs
     global config
-    global lifxList 
+    global lifxList
     global lifxDict
     global config
     bulbList.clear()
@@ -420,7 +420,7 @@ def finder():
         lan = lifxlan.LifxLAN(int(gExpectedBulbs) if int(gExpectedBulbs) != 0 else None)
         bulbs = lan.get_lights()
         #print(type(bulbs))
-        #print(bulbs[0].label) 
+        #print(bulbs[0].label)
         if len(bulbs) < 1:
             app.errorBox("Error", "No bulbs found. Please try again.")
             app.setLabelBg("lbl2","red")
@@ -429,7 +429,7 @@ def finder():
         else:
             app.setLabelBg("lbl2","green")
             app.hideLabel("f1")
-        
+
         app.setLabel("lbl2", "Found "+str(len(bulbs))+" bulbs")
         app.setCheckBox("Select All")
         #app.setSpinBox("Expected Bulbs", str(len(bulbs)))
@@ -451,16 +451,16 @@ def finder():
         #print(lifxList)
         #config['bulbs'] = lifxList
         pkl.dump(lifxList, open(PICKLE, "wb" ))   #this pickles
-#exit(0)        
+#exit(0)
         #config.write()
-        
-    
+
+
     except Exception as e:
         print ("Ignoring error:", str(e))
         app.setLabelBg("lbl2","gray")
         app.setLabel("lbl2", "Found 0 bulbs")
         app.errorBox("Error", str(e)+"\n\nPlease try again. If you keep getting this error, check/toggle your WiFi, ensure that 'Expected Bulbs' is either 0 or the number of bulbs you have and finally, try restarting the app")
-        
+
 #    config['bulbs'] = bulbs
 #    config.write()
     print ("finder() Ended")
@@ -472,9 +472,9 @@ def press(name):
     global lan
     global gwaveformcolor
     global selected_bulb
-    
+
     #print(name, "button pressed")
-    
+
     if (name == "Find Bulbs") :
         finder()
     elif (name == "All Off"):
@@ -488,16 +488,16 @@ def press(name):
         for bulb in bulbs:
             hue = (randint(0, 65535))
             sat = (randint(40000, 65535))
-            bulb.set_color([hue, sat, 65535, 3500],duration=0, rapid=True)     
+            bulb.set_color([hue, sat, 65535, 3500],duration=0, rapid=True)
             if (bulb.label == selected):
                 h = hue/65535.0;#print("h:",h)
                 s = sat/65535.0;#print("s:",s)
                 v = 1;#print("v:",v)
                 rgb1= hsv_to_rgb(h,s,v);#print("rgb1:",rgb1)
-                c = Color(rgb=(rgb1[0], rgb1[1], rgb1[2])) 
+                c = Color(rgb=(rgb1[0], rgb1[1], rgb1[2]))
                 app.setLabelBg("bulbcolor", c.hex_l)
                 updateSliders([hue,sat,65535,3500])
-            
+
     elif (name == "All On"):
         if len(bulbs) < 1:
             return
@@ -505,10 +505,10 @@ def press(name):
     elif (name == "All White"):
         if len(bulbs) < 1:
             return
-        lan.set_color_all_lights([0,0,65535,3500],duration=0, rapid=True)     
+        lan.set_color_all_lights([0,0,65535,3500],duration=0, rapid=True)
         updateSliders([0,0,65535,3500])
         app.setLabelBg("bulbcolor", "#FFFFFF")
-           
+
     elif (name == "Execute") :
         waveform = app.getRadioButton("waveform")
         if waveform == "Saw":
@@ -527,10 +527,10 @@ def press(name):
             is_transient = 1
         else:
             is_transient = 0
-            
+
         #print("is_transient:",is_transient)
         #pickedColor = app.getLabelBg("lblwaveformcolor")
-        
+
         c = Color(str(gwaveformcolor))
         hsv = rgb_to_hsv(c.red,c.green,c.blue)
         #print("hsv:",hsv)
@@ -542,17 +542,17 @@ def press(name):
         #print("period:",period)
         #print("cycles:",cycles)
         #print("duty_cycle:",duty_cycle)
-        
+
         if gSelectAll:
             lan.set_waveform_all_lights(is_transient, bulbHSBK, period, cycles, duty_cycle, waveform, [1])
-            
+
         elif selected_bulb:
             #print("sending color",hsv)
-            selected_bulb.set_waveform(is_transient, bulbHSBK, period, cycles, duty_cycle, waveform)     
+            selected_bulb.set_waveform(is_transient, bulbHSBK, period, cycles, duty_cycle, waveform)
         else:
             app.errorBox("Error", "Error. No bulb was selected. Please select a bulb from the pull-down menu (or tick the 'Select All' checkbox) and try again.")
-            return        
-        
+            return
+
     elif (name == "Secondary Color") :
         pickedColor = app.colourBox(colour="#FF0000")
         app.setLabelBg("lblwaveformcolor", pickedColor)
@@ -576,32 +576,32 @@ def press(name):
         else:
             app.errorBox("Error", "Error. No bulb was selected. Please select a bulb from the pull-down menu (or tick the 'Select All' checkbox) and try again.")
             return
-        
+
         updateSliders(bulbHSBK)
 
-        
+
     elif (name == "Light") :
         #print("selected: ",selected_bulb.label)
         #print("Power is Currently: {}".format(selected_bulb.power_level))
         try:
-            onOff = selected_bulb.power_level; 
+            onOff = selected_bulb.power_level;
         except Exception as e:
             print ("Ignoring error:", str(e))
             app.errorBox("Error", str(e)+"\n\nTry selecting a bulb from the list first.")
             return
-            
+
         #selected_bulb.set_power(not selected_bulb.get_power(), duration=0, rapid=True)
-        
+
         if "Power: Off" in details:
             selected_bulb.set_power(65535, duration=0, rapid=False)
             try:
                 app.setButtonImage("Light","bulb_on.gif");#print("PowerOn");
             except Exception as e:
                 print ("Ignoring error:", str(e))
-            details = details.replace("Power: Off", "Power: On"); 
+            details = details.replace("Power: Off", "Power: On");
             app.clearTextArea("Result")
             app.setTextArea("Result", details)
-            
+
         else:
             selected_bulb.set_power(0, duration=0, rapid=False)
             try:
@@ -611,11 +611,11 @@ def press(name):
             details = details.replace("Power: On", "Power: Off"); #print("details:\n",details)
             app.clearTextArea("Result")
             app.setTextArea("Result", details)
-            
+
         app.setButton ( "Light", "Toggle "+(app.getOptionBox("LIFX Bulbs")) )
         app.showButton("Light")
-        
-        
+
+
         #listChanged()
 
 def rainbow_press(name):
@@ -662,125 +662,70 @@ def followDesktop():
     screen_width = app.winfo_screenwidth()
     screen_height = app.winfo_screenheight()
     print("screen_width:",screen_width," screen_height:",screen_height)
-    print("Follow:",is_follow)  
+    print("Follow:",is_follow)
     mysize = 128, 128
     duration = app.getEntry("Duration")
     print("r:",r)
     print("Starting Loop")
-    
-    while (is_follow):
-     #input("Press Enter to continue...")
-     app.hideEntry("Duration")
-     # Clear colour accumulators 
-     red   = 0
-     green = 0
-     blue  = 0
- 
-     left   = r[0]      # The x-offset of where your crop box starts
-     top    = r[1]    # The y-offset of where your crop box starts
-     width  = r[2]   # The width  of crop box
-     height = r[3]    # The height of crop box
-     box    = (left, top, left+width, top+height)
 
+    #input("Press Enter to continue...")
+    app.hideEntry("Duration")
+
+    left   = r[0]      # The x-offset of where your crop box starts
+    top    = r[1]    # The y-offset of where your crop box starts
+    width  = r[2]   # The width  of crop box
+    height = r[3]    # The height of crop box
+    box    = (left, top, left+width, top+height)
+
+    prev_timestamp = 0
+    duration_secs = float(duration)/1000.0
+
+    while (is_follow):
      # take a screenshot
      image = ImageGrab.grab(bbox=box)
-     #image.show()
-     #image.thumbnail(mysize)
-     #image.show()
-     #with mss() as sct:
-     #   monitor = {'top': top, 'left': left, 'width': width, 'height': height}
-     #   im = sct.grab(monitor)
-     #   img = cv2.imread(im)
-        
-     #printscreen_numpy = np.array(image.getdata(),dtype='uint8').reshape((image.size[1],image.size[0],3)) 
-     img = np.array(image.convert('RGB'))
-     #cv2.imshow("window",printscreen_numpy)
-     #cv2.waitKey(0)
-     #img = cv2.imread(im)
+
+     # calculate average R, G, and B values
      #start = time.clock()
-     
-     #average_color = [img[:, :, i].mean() for i in range(img.shape[-1])]
-     
-     arr = np.float32(img)
-     pixels = arr.reshape((-1, 3))
-     n_colors = 1
-     criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 200, .1)
-     flags = cv2.KMEANS_RANDOM_CENTERS
-     _, labels, centroids = cv2.kmeans(pixels, n_colors, None, criteria, 10, flags)
-     palette = np.uint8(centroids)
-     quantized = palette[labels.flatten()]
-     quantized = quantized.reshape(img.shape)
-     dominant_color = palette[np.argmax(itemfreq(labels)[:, -1])]
+     pixels = np.array(image.convert('RGB'), dtype=np.float32)
+     dominant_color = [np.mean(pixels[:,:,:1]), np.mean(pixels[:,:,:2]), np.mean(pixels[:,:,:3])]
      #print ("time1:",time.clock() - start)
-     #print ("average_color: ",average_color)
-     #print("dominant_color: ",dominant_color)
-     
-     '''
-     #start = time.clock()
-     width, height = image.size
-     for y in range(0, height, DECIMATE):  #loop over the height
-         for x in range(0, width, DECIMATE):  #loop over the width 
-             #print "\n coordinates   x:%d y:%d \n" % (x,y)
-             color = image.getpixel((x, y))  #grab a pixel
-             # calculate sum of each component (RGB)
-             red = red + color[0]
-             green = green + color[1]
-             blue = blue + color[2]
-             #print red + " " +  green + " " + blue
-             #print "\n totals   red:%s green:%s blue:%s\n" % (red,green,blue)
-             #print color
-     #print(time.clock())
+     #print("dominant color in RGB: ", dominant_color)
 
-     # calculate the averages
-     red = (( red / ( (height/DECIMATE) * (width/DECIMATE) ) ) )/255.0
-     green = ((green / ( (height/DECIMATE) * (width/DECIMATE) ) ) )/255.0
-     blue = ((blue / ( (height/DECIMATE) * (width/DECIMATE) ) ) )/255.0
+     # calculate HSBK from RGB
+     dominant_color = np.divide(dominant_color, 255.0)
+     hsv = rgb_to_hsv(dominant_color[0], dominant_color[1], dominant_color[2])
+     bulbHSBK = [hsv[0]*65535.0, hsv[1]*65535.0, hsv[2]*65535.0, 3500]
 
-     # generate a composite colour from these averages
-     c = Color(rgb=(red, green, blue))
-     #print (c)
-     print("c.red:",c.red," c.green:",c.green," c.blue:",c.blue)
-     #print ("time2: ",time.clock() - start)
-     #print ("\naverage1  red:%s green:%s blue:%s" % (red,green,blue))
-     #print ("average1   hue:%f saturation:%f luminance:%f" % (c.hue,c.saturation,c.luminance))
-     #print ("average1  (hex) "+  (c.hex))
-    
-     #hsv = rgb_to_hsv(c.red,c.green,c.blue)
-     '''
-     #hsv = rgb_to_hsv(average_color[0]/255.0, average_color[1]/255.0, average_color[2]/255.0)
-     hsv = rgb_to_hsv(dominant_color[0]/255.0, dominant_color[1]/255.0, dominant_color[2]/255.0)
-     
-     #print("hsv:",hsv)
-     bulbHSBK = [hsv[0]*65535.0,hsv[1]*65535.0,hsv[2]*65535.0,3500]
-     #print ("bulbHSBK:",bulbHSBK)
-     #exit(0)
+     # send command to lights
      try:
          if gSelectAll:
              lan.set_color_all_lights(bulbHSBK, duration=duration, rapid=True)
          elif selected_bulb:
-             #print("sending color",hsv)
              selected_bulb.set_color(bulbHSBK, duration=duration, rapid=True)
          else:
              app.errorBox("Error", "Error. No bulb was selected. Please select a bulb from the pull-down menu (or tick the 'Select All' checkbox) and try again.")
              app.setCheckBox("Follow Desktop",False)
              is_follow = False
-             return        
+             return
      except Exception as e:
          print ("Ignoring error:", str(e))
-    
-    print("Exiting loop")
-    
+
+     # wait to avoid spamming the lights and causing jitters
+     base_delay = 0.002 # wait at least this long for the light firmware
+     time.sleep(base_delay + duration_secs) # add additional time for transition
+     print("Exiting loop")
+
 def iswindows():
   os = java.lang.System.getProperty( "os.name" )
-  return "win" in os.lower()    
-    
+  return "win" in os.lower()
+
 def followDesktopPressed(name):
     global is_follow
     global r
     is_follow = app.getCheckBox("Follow Desktop")
     app.showEntry("Duration")
     if (is_follow):
-        print("Pressed:",name," Follow:",is_follow)  
+        print("Pressed:",name," Follow:",is_follow)
         app.setTransparency(0)
         app.infoBox("Select Region", "A new window entitled \"Screenshot\" will pop up. Drag a rectangle around the region of interest and press ENTER (might have to press it twice). This region's dominant color will be sent to the bulbs to match. To Cancel, press c (maybe twice).", parent=None)
         myos = system()
@@ -790,12 +735,12 @@ def followDesktopPressed(name):
             open_cv_image = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
         elif (myos == 'Windows'):
             print("Windows OS detected.")
-            open_cv_image = np.array(image) 
-        
-        # Convert RGB to BGR 
-        im = open_cv_image[:, :, ::-1].copy() 
-        cv2.namedWindow("Screenshot", cv2.WINDOW_FULLSCREEN) 
-        cv2.moveWindow("Screenshot", 0, 0) 
+            open_cv_image = np.array(image)
+
+        # Convert RGB to BGR
+        im = open_cv_image[:, :, ::-1].copy()
+        cv2.namedWindow("Screenshot", cv2.WINDOW_FULLSCREEN)
+        cv2.moveWindow("Screenshot", 0, 0)
         r = cv2.selectROI("Screenshot", im, False)
         #cv2.waitKey()
         print("r is",r)
@@ -809,7 +754,7 @@ def followDesktopPressed(name):
         #cv2.waitKey(0)
         cv2.destroyAllWindows()
         app.setTransparency(1)
-        app.thread(followDesktop)    
+        app.thread(followDesktop)
 
 
 bulbList = ["-None-          "]
@@ -952,7 +897,7 @@ app.setSticky("news")
 app.addLabel("bulbcolor", "", 0, 3, 3,3)
 app.setLabel("bulbcolor"," ")
 app.setLabelHeight("bulbcolor", 5)
-app.setLabelWidth("bulbcolor", 10) 
+app.setLabelWidth("bulbcolor", 10)
 app.setLabelBg("bulbcolor", "gray")
 app.stopLabelFrame()
 
@@ -1032,9 +977,9 @@ if not os.path.exists(CONFIG):
     config['Scene 2'] = "Scene 2"
     config['Scene 3'] = "Scene 3"
     config['bulbs'] = {}
-    
+
     config.write()
-    
+
 
 #print(".ini file exists")
 config = ConfigObj(CONFIG)
@@ -1050,9 +995,9 @@ if os.path.exists(PICKLE):
     #print (bulbPickle)
     bulbList.clear()
     bulbList.append("-Select Bulb-")
-    
+
     for i, bulb in enumerate(bulbPickle):
-        #print ("mac:",bulb['mac']); 
+        #print ("mac:",bulb['mac']);
         light = lifxlan.Light(bulb['mac'],bulb['ip'])
         light.label = bulb['label']
         bulbs.append(light)
@@ -1063,10 +1008,10 @@ if os.path.exists(PICKLE):
         app.changeOptionBox("LIFX Bulbs", bulbList, callFunction=False)
         app.setLabelBg("lbl2","green")
         app.hideLabel("f1")
-        app.setLabel("lbl2", "Recalled "+str(len(bulbs))+" bulbs")        
+        app.setLabel("lbl2", "Recalled "+str(len(bulbs))+" bulbs")
         app.setCheckBox("Select All")
-    
-            
+
+
 #light = Light("12:34:56:78:9a:bc", "192.168.1.42")
 #print("bulbs:",bulbs)
 lan = lifxlan.LifxLAN()


### PR DESCRIPTION
This PR has a lot of whitespace changes where tabs were automatically replaced by my editor with spaces. I'd understand if the PR is rejected for that. 

All of the actual changes are in the `followDesktop` function. The biggest change is that the average RGB value calculation is done with two lines of numpy array operations, which results in an order of magnitude speedup over the Open CV approach (0.013 seconds vs 0.193 seconds). This doesn't cause that much improvement in the responsiveness of the lights, because that seems to be capped by the ability of the lights themselves to handle messages. Since the new `followDesktop` function is way faster than what the lights can handle, there is currently a delay built in (approximately the light transition time) to prevent the programming from spamming the lights at max speed.

**tl;dr:** The lights don't look that different, but the computer can get away with doing fewer calculations and spending its computational power on other tasks.
